### PR TITLE
Fix bugs of stage-2 translation

### DIFF
--- a/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/L2TLB.scala
@@ -142,11 +142,12 @@ class L2TLBImp(outer: L2TLB)(implicit p: Parameters) extends PtwModule(outer) wi
   llptw.io.hptw.req.ready := hptw_req_arb.io.in(InHptwArbLLPTWPort).ready
 
   // arb2 input port
-  val InArbPTWPort = 0
-  val InArbMissQueuePort = 1
-  val InArbTlbPort = 2
-  val InArbPrefetchPort = 3
-  val InArbHPTWPort = 4
+  val InArbPTWPort       = 0
+  val InArbHPTWPort      = 1
+  val InArbMissQueuePort = 2
+  val InArbTlbPort       = 3
+  val InArbPrefetchPort  = 4
+
   // NOTE: when cache out but miss and ptw doesnt accept,
   arb1.io.in <> VecInit(io.tlb.map(_.req(0)))
  

--- a/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
+++ b/src/main/scala/xiangshan/cache/mmu/MMUBundle.scala
@@ -1069,7 +1069,7 @@ class HptwResp(implicit p: Parameters) extends PtwBundle {
     val hit0 = entry.tag(vpnLen - 1, vpnnLen * 2) === gvpn(vpnLen - 1, vpnnLen * 2)
     val hit1 = entry.tag(vpnnLen * 2  - 1, vpnnLen) === gvpn(vpnnLen * 2 - 1, vpnnLen)
     val hit2 = entry.tag(vpnnLen - 1, 0) === gvpn(vpnnLen - 1, 0)
-    vmid_hit && Mux(entry.level.getOrElse(0.U) === 2.U, hit2 && hit1 && hit0, Mux(entry.level.getOrElse(0.U) === 1.U, hit1 && hit0, hit0))
+    vmid_hit && hit2 && hit1 && hit0
   }
 }
 

--- a/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
+++ b/src/main/scala/xiangshan/cache/mmu/PageTableWalker.scala
@@ -126,8 +126,8 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   val hptw_pageFault = RegInit(false.B)
   val hptw_accessFault = RegInit(false.B)
   val last_s2xlate = RegInit(false.B)
-  val stage1Hit = RegEnable(io.req.bits.stage1Hit, io.req.fire())
-  val stage1 = RegEnable(io.req.bits.stage1, io.req.fire())
+  val stage1Hit = RegEnable(io.req.bits.stage1Hit, io.req.fire)
+  val stage1 = RegEnable(io.req.bits.stage1, io.req.fire)
   val hptw_resp_stage2 = Reg(Bool()) 
 
   val ppn_af = pte.isAf()
@@ -139,7 +139,7 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   val l2addr = MakeAddr(Mux(l1Hit, ppn, pte.ppn), getVpnn(vpn, 1))
   val mem_addr = Mux(af_level === 0.U, l1addr, l2addr)
 
-  val hptw_resp = RegEnable(io.hptw.resp.bits.h_resp, io.hptw.resp.fire())
+  val hptw_resp = RegEnable(io.hptw.resp.bits.h_resp, io.hptw.resp.fire)
   val gpaddr = MuxCase(mem_addr, Seq(
     stage1Hit -> Cat(stage1.genPPN(), 0.U(offLen.W)),
     onlyS2xlate -> Cat(vpn, 0.U(offLen.W)),
@@ -184,23 +184,23 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   io.hptw.req.bits.gvpn := get_pn(gpaddr)
   io.hptw.req.bits.source := source
 
-  when (io.req.fire() && io.req.bits.stage1Hit){
+  when (io.req.fire && io.req.bits.stage1Hit){
     idle := false.B
     req_s2xlate := io.req.bits.req_info.s2xlate
     s_hptw_req := false.B
     hptw_resp_stage2 := false.B
   }
 
-  when (io.hptw.resp.fire() && w_hptw_resp === false.B && stage1Hit){
+  when (io.hptw.resp.fire && w_hptw_resp === false.B && stage1Hit){
     w_hptw_resp := true.B
     hptw_resp_stage2 := true.B
   }
 
-  when (io.resp.fire() && stage1Hit){
+  when (io.resp.fire && stage1Hit){
     idle := true.B
   }
 
-  when (io.req.fire() && !io.req.bits.stage1Hit){
+  when (io.req.fire && !io.req.bits.stage1Hit){
     val req = io.req.bits
     level := Mux(req.l1Hit, 1.U, 0.U)
     af_level := Mux(req.l1Hit, 1.U, 0.U)
@@ -219,12 +219,12 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     }
   }
 
-  when(io.hptw.req.fire() && s_hptw_req === false.B){
+  when(io.hptw.req.fire && s_hptw_req === false.B){
     s_hptw_req := true.B
     w_hptw_resp := false.B
   }
 
-  when(io.hptw.resp.fire() && w_hptw_resp === false.B && !stage1Hit) {
+  when(io.hptw.resp.fire && w_hptw_resp === false.B && !stage1Hit) {
     hptw_pageFault := io.hptw.resp.bits.h_resp.gpf
     hptw_accessFault := io.hptw.resp.bits.h_resp.gaf
     w_hptw_resp := true.B
@@ -236,12 +236,12 @@ class PTW()(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     }
   }
 
-  when(io.hptw.req.fire() && s_last_hptw_req === false.B) {
+  when(io.hptw.req.fire && s_last_hptw_req === false.B) {
     w_last_hptw_resp := false.B
     s_last_hptw_req := true.B
   }
 
-  when(io.hptw.resp.fire() && w_last_hptw_resp === false.B){
+  when(io.hptw.resp.fire && w_last_hptw_resp === false.B){
     hptw_pageFault := io.hptw.resp.bits.h_resp.gpf
     hptw_accessFault := io.hptw.resp.bits.h_resp.gaf
     w_last_hptw_resp := true.B
@@ -460,7 +460,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   val dup_vec = state.indices.map(i =>
     dup(io.in.bits.req_info.vpn, entries(i).req_info.vpn) && io.in.bits.req_info.s2xlate === entries(i).req_info.s2xlate
   )
-  val dup_req_fire = mem_arb.io.out.fire() && dup(io.in.bits.req_info.vpn, mem_arb.io.out.bits.req_info.vpn) && io.in.bits.req_info.s2xlate === mem_arb.io.out.bits.req_info.s2xlate // dup with the req fire entry
+  val dup_req_fire = mem_arb.io.out.fire && dup(io.in.bits.req_info.vpn, mem_arb.io.out.bits.req_info.vpn) && io.in.bits.req_info.s2xlate === mem_arb.io.out.bits.req_info.s2xlate // dup with the req fire entry
   val dup_vec_wait = dup_vec.zip(is_waiting).map{case (d, w) => d && w} // dup with "mem_waiting" entres, sending mem req already
   val dup_vec_having = dup_vec.zipWithIndex.map{case (d, i) => d && is_having(i)} // dup with the "mem_out" entry recv the data just now
   val wait_id = Mux(dup_req_fire, mem_arb.io.chosen, ParallelMux(dup_vec_wait zip entries.map(_.wait_id)))
@@ -494,19 +494,19 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
   }
 
   val enq_ptr_reg = RegNext(enq_ptr)
-  val need_addr_check = RegNext(enq_state === state_addr_check && io.in.fire() && !flush)
+  val need_addr_check = RegNext(enq_state === state_addr_check && io.in.fire && !flush)
     
   val hasHptwResp = ParallelOR(state.map(_ === state_hptw_resp)).asBool
   val hptw_resp_ptr_reg = RegNext(io.hptw.resp.bits.id)
-  val hptw_need_addr_check = RegNext(hasHptwResp && io.hptw.resp.fire() && !flush)
+  val hptw_need_addr_check = RegNext(hasHptwResp && io.hptw.resp.fire && !flush)
 
   val pte = io.mem.resp.bits.value.asTypeOf(new PteBundle().cloneType)
   val gpaddr = MakeGPAddr(io.in.bits.ppn, getVpnn(io.in.bits.req_info.vpn, 0))
   val hptw_resp = io.hptw.resp.bits.h_resp
   val hpaddr = Cat(hptw_resp.genPPNS2(get_pn(gpaddr)), get_off(gpaddr))
-  val hpaddr_reg = RegEnable(hpaddr, hasHptwResp && io.hptw.resp.fire())
+  val hpaddr_reg = RegEnable(hpaddr, hasHptwResp && io.hptw.resp.fire)
   val addr = MakeAddr(io.in.bits.ppn, getVpnn(io.in.bits.req_info.vpn, 0))
-  val addr_reg = RegEnable(addr, io.in.fire())
+  val addr_reg = RegEnable(addr, io.in.fire)
   io.pmp.req.valid := need_addr_check || hptw_need_addr_check
   io.pmp.req.bits.addr := Mux(enableS2xlate, hpaddr, addr)
   io.pmp.req.bits.cmd := TlbCmd.read
@@ -540,7 +540,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     }
   }
 
-  when (DelayN(io.mem.resp.fire(), 1)) {
+  when (DelayN(io.mem.resp.fire, 1)) {
     state.indices.map{i =>
       when (state(i) === state_last_hptw_req && io.mem.resp.bits.id === entries(i).wait_id) {
         entries(i).ppn := pte.ppn // for last stage 2 translation
@@ -548,7 +548,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     }
   }
 
-  when (hyper_arb1.io.out.fire()) {
+  when (hyper_arb1.io.out.fire) {
     for (i <- state.indices) {
       when (state(i) === state_hptw_req && entries(i).ppn === hyper_arb1.io.out.bits.ppn && entries(i).s2xlate) {
         state(i) := state_hptw_resp
@@ -557,7 +557,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     }
   }
 
-  when (hyper_arb2.io.out.fire()) {
+  when (hyper_arb2.io.out.fire) {
     for (i <- state.indices) {
       when (state(i) === state_last_hptw_req && entries(i).ppn === hyper_arb2.io.out.bits.ppn && entries(i).s2xlate) {
         state(i) := state_last_hptw_resp
@@ -566,7 +566,7 @@ class LLPTW(implicit p: Parameters) extends XSModule with HasPtwConst with HasPe
     }
   }
 
-  when (io.hptw.resp.fire()) {
+  when (io.hptw.resp.fire) {
     for (i <- state.indices) {
       when (state(i) === state_hptw_resp && io.hptw.resp.bits.id === entries(i).wait_id) {
         state(i) := state_addr_check
@@ -726,7 +726,7 @@ class HPTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
 
   val resp_valid = !idle && mem_addr_update && ((w_mem_resp && find_pte) || (s_pmp_check && accessFault))
   val id = Reg(UInt(log2Up(l2tlbParams.llptwsize).W))
-  val source = RegEnable(io.req.bits.source, io.req.fire())
+  val source = RegEnable(io.req.bits.source, io.req.fire)
 
   io.req.ready := idle
   val resp = Wire(new HptwResp())
@@ -750,7 +750,7 @@ class HPTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
   io.refill.req_info.source := source
   io.refill.req_info.s2xlate := onlyStage2
   when (idle){
-    when(io.req.fire()){
+    when(io.req.fire){
       level := Mux(io.req.bits.l2Hit, 2.U, Mux(io.req.bits.l1Hit, 1.U, 0.U))
       idle := false.B
       gpaddr := Cat(io.req.bits.gvpn, 0.U(offLen.W))
@@ -774,12 +774,12 @@ class HPTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
     mem_addr_update := true.B
   }
 
-  when(io.mem.req.fire()){
+  when(io.mem.req.fire){
     s_mem_req := true.B
     w_mem_resp := false.B
   }
 
-  when(io.mem.resp.fire() && !w_mem_resp){
+  when(io.mem.resp.fire && !w_mem_resp){
     w_mem_resp := true.B
     mem_addr_update := true.B
   }
@@ -790,7 +790,7 @@ class HPTW()(implicit p: Parameters) extends XSModule with HasPtwConst {
       s_mem_req := false.B
       mem_addr_update := false.B
     }.elsewhen(resp_valid){
-      when(io.resp.fire()){
+      when(io.resp.fire){
         idle := true.B
         mem_addr_update := false.B
         accessFault := false.B

--- a/src/main/scala/xiangshan/cache/mmu/Repeater.scala
+++ b/src/main/scala/xiangshan/cache/mmu/Repeater.scala
@@ -184,7 +184,7 @@ class PTWFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameters) 
     s2xlate === resp.s2xlate && Mux(enableS2xlate && onlyS2, s2hit, s1hit)
   }
 
-  when (io.ptw.req(0).fire =/= io.ptw.resp.fire()) {
+  when (io.ptw.req(0).fire =/= io.ptw.resp.fire) {
     inflight_counter := Mux(io.ptw.req(0).fire, inflight_counter + 1.U, inflight_counter - 1.U)
   }
 

--- a/src/main/scala/xiangshan/cache/mmu/TLB.scala
+++ b/src/main/scala/xiangshan/cache/mmu/TLB.scala
@@ -67,7 +67,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   val flush_pipe = io.flushPipe
 
   val req_in = req
-  val req_out = req.map(a => RegEnable(a.bits, a.fire()))
+  val req_out = req.map(a => RegEnable(a.bits, a.fire))
   val req_out_v = (0 until Width).map(i => ValidHold(req_in(i).fire && !req_in(i).bits.kill, resp(i).fire, flush_pipe(i)))
 
   val isHyperInst = (0 until Width).map(i => req_out_v(i) && req_out(i).hyperinst)
@@ -104,7 +104,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
   val portTranslateEnable = (0 until Width).map(i => (vmEnable(i) || s2xlateEnable(i)) && RegNext(!req(i).bits.no_translate))
 
 
-  val refill = (0 until Width).map(i => ptw.resp.fire() && !(need_gpa && need_gpa_vpn === ptw.resp.bits.getVpn) && !flush_mmu && (vmEnable(i) || ptw.resp.bits.s2xlate =/= noS2xlate))
+  val refill = (0 until Width).map(i => ptw.resp.fire && !(need_gpa && need_gpa_vpn === ptw.resp.bits.getVpn) && !flush_mmu && (vmEnable(i) || ptw.resp.bits.s2xlate =/= noS2xlate))
   refill_to_mem := DontCare
   val entries = Module(new TlbStorageWrapper(Width, q, nRespDups))
   entries.io.base_connect(sfence, csr, satp)
@@ -150,7 +150,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
     val enable = portTranslateEnable(i)
     val isOnlys2xlate = req_out_s2xlate(i) === onlyStage2
     val resp_gpa_refill = RegInit(false.B)
-    val need_gpa_vpn_hit = RegEnable(need_gpa_vpn === get_pn(req_in(i).bits.vaddr), req_in(i).fire())
+    val need_gpa_vpn_hit = RegEnable(need_gpa_vpn === get_pn(req_in(i).bits.vaddr), req_in(i).fire)
     when (io.requestor(i).resp.valid && hasGpf(i) && need_gpa === false.B && !need_gpa_vpn_hit && !isOnlys2xlate) {
       need_gpa := true.B
       need_gpa_vpn := get_pn(req_out(i).vaddr)
@@ -307,7 +307,7 @@ class TLB(Width: Int, nRespDups: Int = 1, Block: Seq[Boolean], q: TLBParameters)
       (vsatp.mode === 0.U) -> onlyStage2,
       (hgatp.mode === 0.U || req_need_gpa) -> onlyStage1
     ))
-    val miss_req_s2xlate_reg = RegEnable(miss_req_s2xlate, io.ptw.req(idx).fire())
+    val miss_req_s2xlate_reg = RegEnable(miss_req_s2xlate, io.ptw.req(idx).fire)
     val hasS2xlate = miss_req_s2xlate_reg =/= noS2xlate
     val onlyS2 = miss_req_s2xlate_reg === onlyStage2
     val hit_s1 = io.ptw.resp.bits.s1.hit(miss_req_vpn, Mux(hasS2xlate, io.csr.vsatp.asid, io.csr.satp.asid), io.csr.hgatp.asid, allType = true, false, hasS2xlate)


### PR DESCRIPTION
1. When executing "stage-2 translation" test in rvh_test, the hptw is always interrupted by ptw requests because the outer request and cache->hptw request comes in the same frequency. Therefore, I think improving the privilege of HPTW will help.
2. When executing "stage-2 translation" test in rvh_test, tlb_ld and tlb_st both send requests for addresses in the same superpage. If dtlb_filter send back results, it will match and send it to both tlb. For example, when tlb_ld send request with vpn (0x00080004) and tlb_st send request with vpn (0x00080015), they both point to the same superpage(level=01). However, they share the same ppn. I think this is because HPTW doesn't implement pteidx comfirmation, which appears in PTWSectorResp. And it may get interfered. What's lucky is that we transfer the whole vpn of request through PageTableCache, ptw, hptw, llptw, and finally L2TLB reponses with it. That's also why we can confirm the whole vpn with that of request.

![image](https://github.com/pxk27/XiangShan/assets/78342819/3a20d67e-d743-4429-acd2-b92820d65f23)
