### PR TITLE
Fix initial value of vsstatus

### DIFF
--- a/src/main/scala/xiangshan/backend/fu/CSR.scala
+++ b/src/main/scala/xiangshan/backend/fu/CSR.scala
@@ -656,7 +656,7 @@ class CSR(implicit p: Parameters) extends FunctionUnit with HasCSRConst with PMP
   val hcounteren = RegInit(UInt(XLEN.W), 0.U)
   val hcounterenMask = 0.U(XLEN.W) //will be used by ZICNTR or ZIHPM
 
-  val vsstatus = RegInit("ha00002000".U(XLEN.W))
+  val vsstatus = RegInit("h200002000".U(XLEN.W))
   val vsstatusStruct = vsstatus.asTypeOf(new MstatusStruct)
   //vsie vsip
   val vsMask = ((1 << 10) | (1 << 6) | (1 << 2)).U(XLEN.W)


### PR DESCRIPTION
According to the RISC-V Manual “[*[The RISC-V Instruction Set Manual, Volume II: Privileged Architecture , 20211203](https://www.five-embeddev.com/riscv-isa-manual/latest/hypervisor.html#virtual-supervisor-status-register-vsstatus)*](https://www.five-embeddev.com/riscv-isa-manual/latest/hypervisor.html#virtual-supervisor-status-register-vsstatus)”. Where the low 34-35 bits are within the WPRI field. 
So the initial value of `vsstatus` should not be **0xa000020000**, which may or may not be overwritten by the program. Besides, it will be copied to difftest without check, but be written with a mask, which incurs a fault once assigning a new value to `vsstatus`.