### PR TITLE
Add s2 level dependency due to the fake leaf for super page

### DIFF
--- a/src/main/scala/xiangshan/backend/MemBlock.scala
+++ b/src/main/scala/xiangshan/backend/MemBlock.scala
@@ -500,7 +500,7 @@ class MemBlockImp(outer: MemBlock) extends LazyModuleImp(outer)
       else Cat(ptw_resp_next.vector.drop(exuParameters.LduCnt + 1 + exuParameters.StuCnt)).orR
     val hasS2xlate = tlb.bits.hasS2xlate()
     val isOnlyStage2 = tlb.bits.isOnlyStage2() && ptw_resp_next.data.isOnlyStage2()
-    val s1_hit = ptw_resp_next.data.s1.hit(tlb.bits.vpn, Mux(hasS2xlate, tlbcsr.vsatp.asid, tlbcsr.satp.asid), tlbcsr.hgatp.asid, allType = true, ignoreAsid = true, hasS2xlate)
+    val s1_hit = ptw_resp_next.data.s1.hit(tlb.bits.vpn, Mux(hasS2xlate, tlbcsr.vsatp.asid, tlbcsr.satp.asid), tlbcsr.hgatp.asid, allType = true, ignoreAsid = true, tlb.bits.s2xlate, ptw_resp_next.data.s2.entry.level.getOrElse(0.U))
     val s2_hit = ptw_resp_next.data.s2.hit(tlb.bits.vpn, tlbcsr.hgatp.asid)
     ptwio.req(i).valid := tlb.valid && !(ptw_resp_v && vector_hit && Mux(isOnlyStage2, s2_hit, s1_hit))
   }

--- a/src/main/scala/xiangshan/cache/mmu/Repeater.scala
+++ b/src/main/scala/xiangshan/cache/mmu/Repeater.scala
@@ -442,7 +442,7 @@ class PTWFilter(Width: Int, Size: Int, FenceDelay: Int)(implicit p: Parameters) 
   def ptwResp_hit(vpn: UInt, s2xlate: UInt, resp: PtwRespS2): Bool = {
     val enableS2xlate = resp.s2xlate =/= noS2xlate
     val onlyS2 = resp.s2xlate === onlyStage2
-    val s1hit = resp.s1.hit(vpn, 0.U, io.csr.hgatp.asid, true, true, enableS2xlate)
+    val s1hit = resp.s1.hit(vpn, 0.U, io.csr.hgatp.asid, true, true, resp.s2xlate, resp.s2.entry.level.getOrElse(0.U))
     val s2hit = resp.s2.hit(vpn, io.csr.hgatp.asid)
     s2xlate === resp.s2xlate && Mux(enableS2xlate && onlyS2, s2hit, s1hit)
   }


### PR DESCRIPTION
We make fake leaf when walking 2 levels of stage-1 translation and 3 levels of stage-2 translation, which makes use of more parts of vpn than that denoted by `s1.level`. Therefore, I argue that the `s2.level` should have an influence on the vpn hit in TLB.